### PR TITLE
La till 30 år

### DIFF
--- a/songs/arskursvisan.tex
+++ b/songs/arskursvisan.tex
@@ -71,7 +71,7 @@ Därför föreslås följande sätt att sjunga längre-än-tvåstaviga namn:
 \item untricesimus
 \item duotricesimus
 \item tricesimus tertius
-\item quartus
+\item tricesimus quartus
 \item tricesimus quintus
 \item tricesimus sextus
 \end{enumerate}


### PR DESCRIPTION
Tricesimus quartus var benämd bara quartus.