### PR TITLE
Render systeme international on web

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7712,6 +7712,21 @@
         "array-includes": "^3.0.3"
       }
     },
+    "katex": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.11.1.tgz",
+      "integrity": "sha512-5oANDICCTX0NqYIyAiFCCwjQ7ERu3DQG2JFHLbYOf+fXaMoH8eg/zOq5WSYJsKMi/QebW+Eh3gSM+oss1H/bww==",
+      "requires": {
+        "commander": "^2.19.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        }
+      }
+    },
     "keycode": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "fuzzysort": "^1.1.4",
+    "katex": "^0.11.1",
     "methone": "^0.6.5",
     "preval.macro": "^3.0.0",
     "react": "^16.7.0-alpha.2",

--- a/songs/systeme_international.tex
+++ b/songs/systeme_international.tex
@@ -8,15 +8,18 @@ Melodi: Studentsången
 Sektion: Fysik
 \end{songmeta}
 
-\noindent W kg m Wb s \\
-$\Omega{}m$ T A rad \\
-cd S N s \\
-OA m lx dB \\
-$^{\circ}C$ $W/m^2$ \\
-J/kg H V C \\
-$kg/m^3$ mol \\
-$m/s^2$ \\
-$m/s^2$ \\
+\begin{songtext}
+W kg m Wb s
+$\Omega{}m$ T A rad
+cd S N s
+$\Omega{}$ A m lx dB
+$^{\circ}C$ $W/m^2$
+J/kg
+H V C
+$kg/m^3$ mol
+$m/s^2$
+$m/s^2$
 $F!$
+\end{songtext}
 
 \end{song}

--- a/src/getSongs.js
+++ b/src/getSongs.js
@@ -1,6 +1,7 @@
 const glob = require('glob')
 const fs = require('fs')
 const path = require('path')
+const katex = require('katex')
 
 const songFiles = glob.sync('./songs/*.tex')
 
@@ -15,6 +16,8 @@ const replacements = [
   [/\\sci\{\}/g, 'I'],
   [/\\ng\{\}/g, 'ŋ'],
   [/\\begin\{math\}\\rho\\end\{math\}/g, 'ρ'],
+  [/\$([^\$]+)\$/g, (_, math) => katex.renderToString(math)],
+  [/\$([^\$]+)\$/g, (_, math) => katex.renderText(math)],
   [/\\sqrt\{(.*)\}/g, '√<span style="text-decoration:overline;">$1</span>'],
   [/\\textquotedblleft\{\}/g, '“'],
   [/\\textquotedblright\{\}/g, '”'],

--- a/src/index.css
+++ b/src/index.css
@@ -8,6 +8,10 @@ body {
   margin-left: 5px;
 }
 
+.katex-html {
+  display: none;
+}
+
 @media only screen and (max-width: 991px) {
   header .header-inner .header-right a.primary-action {
     display: none;


### PR DESCRIPTION
This adds another js dependency, `katex`, in order to more properly render math blocks (`$...$` and `$$...$$`) where they occur in songs.

This was done in order to get "Système International" to render at all on the web version.

This is how it currently looks on https://audio.datasektionen.se/systeme_international#systeme_international: 

![2020-04-30-134024_464x373_scrot](https://user-images.githubusercontent.com/2308/80706228-3eddf200-8ae8-11ea-9e83-d49aecafa511.png)

Here's how it looks locally for me with these changes:

![2020-04-30-134213_459x483_scrot](https://user-images.githubusercontent.com/2308/80706325-6a60dc80-8ae8-11ea-8e93-c9e59e85ec3d.png)

It also accidentally tidies up the square root in the notes of "En matematiker":

![2020-04-30-134335_163x67_scrot](https://user-images.githubusercontent.com/2308/80706418-9b411180-8ae8-11ea-85b6-4603baf100de.png)

